### PR TITLE
Extend schemas

### DIFF
--- a/tap_recurly/schemas/accounts.json
+++ b/tap_recurly/schemas/accounts.json
@@ -22,7 +22,12 @@
         "string"
       ]
     },
-    "parent_account_id": {},
+    "parent_account_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "bill_to": {
       "type": [
         "null",
@@ -59,7 +64,12 @@
         "string"
       ]
     },
-    "preferred_time_zone": {},
+    "preferred_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "first_name": {
       "type": [
         "null",
@@ -90,7 +100,12 @@
         "boolean"
       ]
     },
-    "exemption_certificate": {},
+    "exemption_certificate": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "address": {
       "type": [
         "null",
@@ -287,7 +302,12 @@
                 "string"
               ]
             },
-            "cc_bin_country": {},
+            "cc_bin_country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "exp_month": {
               "type": [
                 "null",
@@ -314,7 +334,32 @@
             }
           }
         },
-        "fraud": {},
+        "fraud": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "score": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "decision": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "risk_rules_triggered": {
+              "type": [
+                "null",
+                "object"
+              ]
+            }
+          }
+        },
         "created_at": {
           "type": [
             "null",
@@ -409,8 +454,18 @@
         "string"
       ]
     },
-    "dunning_campaign_id": {},
-    "invoice_template_id": {},
+    "dunning_campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "invoice_template_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "shipping_addresses": {
       "type": [
         "null",
@@ -538,7 +593,26 @@
         "null",
         "array"
       ],
-      "items": {}
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
     }
   }
 }

--- a/tap_recurly/schemas/accounts.json
+++ b/tap_recurly/schemas/accounts.json
@@ -22,11 +22,7 @@
         "string"
       ]
     },
-    "parent_account_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "parent_account_id": {},
     "bill_to": {
       "type": [
         "null",
@@ -63,11 +59,7 @@
         "string"
       ]
     },
-    "preferred_time_zone": {
-      "type": [
-        "null"
-      ]
-    },
+    "preferred_time_zone": {},
     "first_name": {
       "type": [
         "null",
@@ -98,11 +90,7 @@
         "boolean"
       ]
     },
-    "exemption_certificate": {
-      "type": [
-        "null"
-      ]
-    },
+    "exemption_certificate": {},
     "address": {
       "type": [
         "null",
@@ -299,11 +287,7 @@
                 "string"
               ]
             },
-            "cc_bin_country": {
-              "type": [
-                "null"
-              ]
-            },
+            "cc_bin_country": {},
             "exp_month": {
               "type": [
                 "null",
@@ -330,11 +314,7 @@
             }
           }
         },
-        "fraud": {
-          "type": [
-            "null"
-          ]
-        },
+        "fraud": {},
         "created_at": {
           "type": [
             "null",
@@ -429,16 +409,8 @@
         "string"
       ]
     },
-    "dunning_campaign_id": {
-      "type": [
-        "null"
-      ]
-    },
-    "invoice_template_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "dunning_campaign_id": {},
+    "invoice_template_id": {},
     "shipping_addresses": {
       "type": [
         "null",

--- a/tap_recurly/schemas/adjustments.json
+++ b/tap_recurly/schemas/adjustments.json
@@ -34,11 +34,7 @@
         "string"
       ]
     },
-    "legacy_category": {
-      "type": [
-        "null"
-      ]
-    },
+    "legacy_category": {},
     "account": {
       "type": [
         "null",
@@ -87,22 +83,14 @@
             "string"
           ]
         },
-        "parent_account_id": {
-          "type": [
-            "null"
-          ]
-        },
+        "parent_account_id": {},
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {
-          "type": [
-            "null"
-          ]
-        }
+        "dunning_campaign_id": {}
       }
     },
     "bill_for_account_id": {
@@ -219,11 +207,7 @@
         "number"
       ]
     },
-    "unit_amount_decimal": {
-      "type": [
-        "null"
-      ]
-    },
+    "unit_amount_decimal": {},
     "subtotal": {
       "type": [
         "null",
@@ -310,26 +294,10 @@
         "number"
       ]
     },
-    "shipping_address": {
-      "type": [
-        "null"
-      ]
-    },
-    "item_code": {
-      "type": [
-        "null"
-      ]
-    },
-    "item_id": {
-      "type": [
-        "null"
-      ]
-    },
-    "external_sku": {
-      "type": [
-        "null"
-      ]
-    },
+    "shipping_address": {},
+    "item_code": {},
+    "item_id": {},
+    "external_sku": {},
     "revenue_schedule_type": {
       "type": [
         "null",

--- a/tap_recurly/schemas/adjustments.json
+++ b/tap_recurly/schemas/adjustments.json
@@ -34,7 +34,12 @@
         "string"
       ]
     },
-    "legacy_category": {},
+    "legacy_category": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "account": {
       "type": [
         "null",
@@ -83,14 +88,24 @@
             "string"
           ]
         },
-        "parent_account_id": {},
+        "parent_account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {}
+        "dunning_campaign_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
     "bill_for_account_id": {
@@ -207,7 +222,12 @@
         "number"
       ]
     },
-    "unit_amount_decimal": {},
+    "unit_amount_decimal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "subtotal": {
       "type": [
         "null",
@@ -294,10 +314,142 @@
         "number"
       ]
     },
-    "shipping_address": {},
-    "item_code": {},
-    "item_id": {},
-    "external_sku": {},
+    "shipping_address": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "nickname": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "first_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "last_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "company": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "email": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "vat_number": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "phone": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "street1": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "street2": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "city": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "region": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "postal_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "item_code": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "item_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "external_sku": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "revenue_schedule_type": {
       "type": [
         "null",

--- a/tap_recurly/schemas/billing_info.json
+++ b/tap_recurly/schemas/billing_info.json
@@ -46,11 +46,7 @@
         "string"
       ]
     },
-    "company": {
-      "type": [
-        "null"
-      ]
-    },
+    "company": {},
     "address": {
       "type": [
         "null",
@@ -93,18 +89,10 @@
             "string"
           ]
         },
-        "phone": {
-          "type": [
-            "null"
-          ]
-        }
+        "phone": {}
       }
     },
-    "vat_number": {
-      "type": [
-        "null"
-      ]
-    },
+    "vat_number": {},
     "valid": {
       "type": [
         "null",
@@ -141,11 +129,7 @@
             "string"
           ]
         },
-        "cc_bin_country": {
-          "type": [
-            "null"
-          ]
-        },
+        "cc_bin_country": {},
         "exp_month": {
           "type": [
             "null",
@@ -172,11 +156,7 @@
         }
       }
     },
-    "fraud": {
-      "type": [
-        "null"
-      ]
-    },
+    "fraud": {},
     "created_at": {
       "type": [
         "null",

--- a/tap_recurly/schemas/billing_info.json
+++ b/tap_recurly/schemas/billing_info.json
@@ -46,7 +46,12 @@
         "string"
       ]
     },
-    "company": {},
+    "company": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "address": {
       "type": [
         "null",
@@ -89,10 +94,20 @@
             "string"
           ]
         },
-        "phone": {}
+        "phone": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
-    "vat_number": {},
+    "vat_number": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "valid": {
       "type": [
         "null",
@@ -129,7 +144,12 @@
             "string"
           ]
         },
-        "cc_bin_country": {},
+        "cc_bin_country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "exp_month": {
           "type": [
             "null",
@@ -156,7 +176,32 @@
         }
       }
     },
-    "fraud": {},
+    "fraud": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "score": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "decision": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "risk_rules_triggered": {
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      }
+    },
     "created_at": {
       "type": [
         "null",

--- a/tap_recurly/schemas/coupon_redemptions.json
+++ b/tap_recurly/schemas/coupon_redemptions.json
@@ -58,18 +58,38 @@
             "string"
           ]
         },
-        "company": {},
-        "parent_account_id": {},
+        "company": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "parent_account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {}
+        "dunning_campaign_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
-    "subscription_id": {},
+    "subscription_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "coupon": {
       "type": [
         "null",
@@ -230,8 +250,84 @@
             "integer"
           ]
         },
-        "unique_code_template": {},
-        "unique_coupon_code": {},
+        "unique_code_template": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "unique_coupon_code": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "object": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "bulk_coupon_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "bulk_coupon_code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "redeemed_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "expired_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
         "plans": {
           "type": [
             "null",
@@ -270,7 +366,56 @@
             }
           }
         },
-        "items": {},
+        "items": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "object": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "state": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "description": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        },
         "redeem_by": {
           "type": [
             "null",
@@ -327,6 +472,12 @@
         "string"
       ]
     },
-    "removed_at": {}
+    "removed_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    }
   }
 }

--- a/tap_recurly/schemas/coupon_redemptions.json
+++ b/tap_recurly/schemas/coupon_redemptions.json
@@ -58,34 +58,18 @@
             "string"
           ]
         },
-        "company": {
-          "type": [
-            "null"
-          ]
-        },
-        "parent_account_id": {
-          "type": [
-            "null"
-          ]
-        },
+        "company": {},
+        "parent_account_id": {},
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {
-          "type": [
-            "null"
-          ]
-        }
+        "dunning_campaign_id": {}
       }
     },
-    "subscription_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "subscription_id": {},
     "coupon": {
       "type": [
         "null",
@@ -246,16 +230,8 @@
             "integer"
           ]
         },
-        "unique_code_template": {
-          "type": [
-            "null"
-          ]
-        },
-        "unique_coupon_code": {
-          "type": [
-            "null"
-          ]
-        },
+        "unique_code_template": {},
+        "unique_coupon_code": {},
         "plans": {
           "type": [
             "null",
@@ -294,11 +270,7 @@
             }
           }
         },
-        "items": {
-          "type": [
-            "null"
-          ]
-        },
+        "items": {},
         "redeem_by": {
           "type": [
             "null",
@@ -355,10 +327,6 @@
         "string"
       ]
     },
-    "removed_at": {
-      "type": [
-        "null"
-      ]
-    }
+    "removed_at": {}
   }
 }

--- a/tap_recurly/schemas/coupons.json
+++ b/tap_recurly/schemas/coupons.json
@@ -158,8 +158,84 @@
         "integer"
       ]
     },
-    "unique_code_template": {},
-    "unique_coupon_code": {},
+    "unique_code_template": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "unique_coupon_code": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "bulk_coupon_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "bulk_coupon_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "redeemed_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "expired_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
     "plans": {
       "type": [
         "null",
@@ -198,7 +274,56 @@
         }
       }
     },
-    "items": {},
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "object": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "redeem_by": {
       "type": [
         "null",

--- a/tap_recurly/schemas/coupons.json
+++ b/tap_recurly/schemas/coupons.json
@@ -158,16 +158,8 @@
         "integer"
       ]
     },
-    "unique_code_template": {
-      "type": [
-        "null"
-      ]
-    },
-    "unique_coupon_code": {
-      "type": [
-        "null"
-      ]
-    },
+    "unique_code_template": {},
+    "unique_coupon_code": {},
     "plans": {
       "type": [
         "null",
@@ -206,11 +198,7 @@
         }
       }
     },
-    "items": {
-      "type": [
-        "null"
-      ]
-    },
+    "items": {},
     "redeem_by": {
       "type": [
         "null",

--- a/tap_recurly/schemas/invoices.json
+++ b/tap_recurly/schemas/invoices.json
@@ -88,29 +88,17 @@
             "string"
           ]
         },
-        "parent_account_id": {
-          "type": [
-            "null"
-          ]
-        },
+        "parent_account_id": {},
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {
-          "type": [
-            "null"
-          ]
-        }
+        "dunning_campaign_id": {}
       }
     },
-    "billing_info_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "billing_info_id": {},
     "subscription_ids": {
       "type": [
         "null",
@@ -123,11 +111,7 @@
         ]
       }
     },
-    "previous_invoice_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "previous_invoice_id": {},
     "number": {
       "type": [
         "null",
@@ -158,11 +142,7 @@
         "object"
       ],
       "properties": {
-        "name_on_account": {
-          "type": [
-            "null"
-          ]
-        },
+        "name_on_account": {},
         "first_name": {
           "type": [
             "null",
@@ -299,11 +279,7 @@
         "string"
       ]
     },
-    "vat_reverse_charge_notes": {
-      "type": [
-        "null"
-      ]
-    },
+    "vat_reverse_charge_notes": {},
     "terms_and_conditions": {
       "type": [
         "null",
@@ -357,11 +333,7 @@
               "string"
             ]
           },
-          "legacy_category": {
-            "type": [
-              "null"
-            ]
-          },
+          "legacy_category": {},
           "account": {
             "type": [
               "null",
@@ -410,22 +382,14 @@
                   "string"
                 ]
               },
-              "parent_account_id": {
-                "type": [
-                  "null"
-                ]
-              },
+              "parent_account_id": {},
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {
-                "type": [
-                  "null"
-                ]
-              }
+              "dunning_campaign_id": {}
             }
           },
           "bill_for_account_id": {
@@ -542,11 +506,7 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {
-            "type": [
-              "null"
-            ]
-          },
+          "unit_amount_decimal": {},
           "subtotal": {
             "type": [
               "null",
@@ -633,26 +593,10 @@
               "number"
             ]
           },
-          "shipping_address": {
-            "type": [
-              "null"
-            ]
-          },
-          "item_code": {
-            "type": [
-              "null"
-            ]
-          },
-          "item_id": {
-            "type": [
-              "null"
-            ]
-          },
-          "external_sku": {
-            "type": [
-              "null"
-            ]
-          },
+          "shipping_address": {},
+          "item_code": {},
+          "item_id": {},
+          "external_sku": {},
           "revenue_schedule_type": {
             "type": [
               "null",
@@ -670,6 +614,13 @@
               "null",
               "string"
             ]
+          },
+          "custom_fields": {
+            "type": [
+              "none",
+              "array"
+            ],
+            "items": {}
           },
           "created_at": {
             "type": [
@@ -763,27 +714,15 @@
                   "string"
                 ]
               },
-              "company": {
-                "type": [
-                  "null"
-                ]
-              },
-              "parent_account_id": {
-                "type": [
-                  "null"
-                ]
-              },
+              "company": {},
+              "parent_account_id": {},
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {
-                "type": [
-                  "null"
-                ]
-              }
+              "dunning_campaign_id": {}
             }
           },
           "invoice": {
@@ -824,11 +763,7 @@
               }
             }
           },
-          "voided_by_invoice": {
-            "type": [
-              "null"
-            ]
-          },
+          "voided_by_invoice": {},
           "subscription_ids": {
             "type": [
               "null",
@@ -949,11 +884,7 @@
                   "string"
                 ]
               },
-              "phone": {
-                "type": [
-                  "null"
-                ]
-              }
+              "phone": {}
             }
           },
           "collection_method": {
@@ -992,11 +923,7 @@
                   "string"
                 ]
               },
-              "cc_bin_country": {
-                "type": [
-                  "null"
-                ]
-              },
+              "cc_bin_country": {},
               "exp_month": {
                 "type": [
                   "null",
@@ -1091,11 +1018,7 @@
               "string"
             ]
           },
-          "gateway_approval_code": {
-            "type": [
-              "null"
-            ]
-          },
+          "gateway_approval_code": {},
           "gateway_response_code": {
             "type": [
               "null",
@@ -1120,11 +1043,7 @@
                   "string"
                 ]
               },
-              "transaction_type": {
-                "type": [
-                  "null"
-                ]
-              }
+              "transaction_type": {}
             }
           },
           "cvv_check": {
@@ -1151,11 +1070,7 @@
               "string"
             ]
           },
-          "voided_at": {
-            "type": [
-              "null"
-            ]
-          },
+          "voided_at": {},
           "collected_at": {
             "type": [
               "null",
@@ -1165,11 +1080,7 @@
         }
       }
     },
-    "shipping_address": {
-      "type": [
-        "null"
-      ]
-    },
+    "shipping_address": {},
     "created_at": {
       "type": [
         "null",
@@ -1295,22 +1206,14 @@
                   "string"
                 ]
               },
-              "parent_account_id": {
-                "type": [
-                  "null"
-                ]
-              },
+              "parent_account_id": {},
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {
-                "type": [
-                  "null"
-                ]
-              }
+              "dunning_campaign_id": {}
             }
           },
           "applied_to_invoice": {
@@ -1401,16 +1304,8 @@
               "number"
             ]
           },
-          "original_credit_payment_id": {
-            "type": [
-              "null"
-            ]
-          },
-          "refund_transaction": {
-            "type": [
-              "null"
-            ]
-          },
+          "original_credit_payment_id": {},
+          "refund_transaction": {},
           "created_at": {
             "type": [
               "null",

--- a/tap_recurly/schemas/invoices.json
+++ b/tap_recurly/schemas/invoices.json
@@ -88,17 +88,32 @@
             "string"
           ]
         },
-        "parent_account_id": {},
+        "parent_account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {}
+        "dunning_campaign_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
-    "billing_info_id": {},
+    "billing_info_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "subscription_ids": {
       "type": [
         "null",
@@ -111,7 +126,12 @@
         ]
       }
     },
-    "previous_invoice_id": {},
+    "previous_invoice_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "number": {
       "type": [
         "null",
@@ -279,7 +299,12 @@
         "string"
       ]
     },
-    "vat_reverse_charge_notes": {},
+    "vat_reverse_charge_notes": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "terms_and_conditions": {
       "type": [
         "null",
@@ -333,7 +358,12 @@
               "string"
             ]
           },
-          "legacy_category": {},
+          "legacy_category": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "account": {
             "type": [
               "null",
@@ -382,14 +412,24 @@
                   "string"
                 ]
               },
-              "parent_account_id": {},
+              "parent_account_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {}
+              "dunning_campaign_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           },
           "bill_for_account_id": {
@@ -506,7 +546,12 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {},
+          "unit_amount_decimal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "subtotal": {
             "type": [
               "null",
@@ -593,10 +638,142 @@
               "number"
             ]
           },
-          "shipping_address": {},
-          "item_code": {},
-          "item_id": {},
-          "external_sku": {},
+          "shipping_address": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "object": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "account_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "nickname": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "first_name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "company": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "email": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "vat_number": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "phone": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "street1": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "street2": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "city": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "region": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "postal_code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "country": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "created_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              }
+            }
+          },
+          "item_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "item_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "external_sku": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "revenue_schedule_type": {
             "type": [
               "null",
@@ -617,10 +794,29 @@
           },
           "custom_fields": {
             "type": [
-              "none",
+              "null",
               "array"
             ],
-            "items": {}
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            }
           },
           "created_at": {
             "type": [
@@ -714,15 +910,30 @@
                   "string"
                 ]
               },
-              "company": {},
-              "parent_account_id": {},
+              "company": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "parent_account_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {}
+              "dunning_campaign_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           },
           "invoice": {
@@ -763,7 +974,44 @@
               }
             }
           },
-          "voided_by_invoice": {},
+          "voided_by_invoice": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "object": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "number": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "state": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          },
           "subscription_ids": {
             "type": [
               "null",
@@ -884,7 +1132,12 @@
                   "string"
                 ]
               },
-              "phone": {}
+              "phone": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           },
           "collection_method": {
@@ -923,7 +1176,12 @@
                   "string"
                 ]
               },
-              "cc_bin_country": {},
+              "cc_bin_country": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "exp_month": {
                 "type": [
                   "null",
@@ -1018,7 +1276,12 @@
               "string"
             ]
           },
-          "gateway_approval_code": {},
+          "gateway_approval_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "gateway_response_code": {
             "type": [
               "null",
@@ -1070,7 +1333,13 @@
               "string"
             ]
           },
-          "voided_at": {},
+          "voided_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
           "collected_at": {
             "type": [
               "null",
@@ -1080,7 +1349,124 @@
         }
       }
     },
-    "shipping_address": {},
+    "shipping_address": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "nickname": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "first_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "last_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "company": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "email": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "vat_number": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "phone": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "street1": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "street2": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "city": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "region": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "postal_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
     "created_at": {
       "type": [
         "null",
@@ -1206,14 +1592,24 @@
                   "string"
                 ]
               },
-              "parent_account_id": {},
+              "parent_account_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "bill_to": {
                 "type": [
                   "null",
                   "string"
                 ]
               },
-              "dunning_campaign_id": {}
+              "dunning_campaign_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           },
           "applied_to_invoice": {
@@ -1304,8 +1700,551 @@
               "number"
             ]
           },
-          "original_credit_payment_id": {},
-          "refund_transaction": {},
+          "original_credit_payment_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "refund_transaction": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "object": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "uuid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "original_transaction_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "account": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "code": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "email": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "email"
+                  },
+                  "first_name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "last_name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "company": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "parent_account_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "bill_to": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "dunning_campaign_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "invoice": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "state": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "voided_by_invoice": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "state": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "subscription_ids": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "origin": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "currency": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "amount": {
+                "type": [
+                  "null",
+                  "number"
+                ],
+                "format": "float"
+              },
+              "status": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "success": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              },
+              "backup_payment_method_used": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              },
+              "refunded": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              },
+              "billing_address": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "phone": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "street1": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "street2": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "city": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "region": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "postal_code": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "country": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "collection_method": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "payment_method": {
+                "properties": {
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "card_type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "first_six": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "last_four": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "last_two": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "exp_month": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "exp_year": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "gateway_token": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "cc_bin_country": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "gateway_code": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "billing_agreement_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name_on_account": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "account_type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "routing_number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "routing_number_bank": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "username": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "ip_address_v4": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "ip_address_country": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "status_code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "status_message": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "customer_message": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "customer_message_locale": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "payment_gateway": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "gateway_message": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "gateway_reference": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "gateway_approval_code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "gateway_response_code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "gateway_response_time": {
+                "type": [
+                  "null",
+                  "number"
+                ],
+                "format": "float"
+              },
+              "gateway_response_values": {
+                "type": [
+                  "null",
+                  "object"
+                ]
+              },
+              "cvv_check": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "avs_check": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "created_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "voided_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "collected_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              }
+            }
+          },
           "created_at": {
             "type": [
               "null",

--- a/tap_recurly/schemas/plans.json
+++ b/tap_recurly/schemas/plans.json
@@ -162,16 +162,8 @@
         "object"
       ],
       "properties": {
-        "success_url": {
-          "type": [
-            "null"
-          ]
-        },
-        "cancel_url": {
-          "type": [
-            "null"
-          ]
-        },
+        "success_url": {},
+        "cancel_url": {},
         "bypass_confirmation": {
           "type": [
             "null",
@@ -198,16 +190,8 @@
         "string"
       ]
     },
-    "deleted_at": {
-      "type": [
-        "null"
-      ]
-    },
-    "dunning_campaign_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "deleted_at": {},
+    "dunning_campaign_id": {},
     "pricing_model": {
       "type": [
         "null",

--- a/tap_recurly/schemas/plans.json
+++ b/tap_recurly/schemas/plans.json
@@ -162,8 +162,18 @@
         "object"
       ],
       "properties": {
-        "success_url": {},
-        "cancel_url": {},
+        "success_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "cancel_url": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bypass_confirmation": {
           "type": [
             "null",
@@ -190,8 +200,19 @@
         "string"
       ]
     },
-    "deleted_at": {},
-    "dunning_campaign_id": {},
+    "deleted_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "dunning_campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "pricing_model": {
       "type": [
         "null",

--- a/tap_recurly/schemas/plans_add_ons.json
+++ b/tap_recurly/schemas/plans_add_ons.json
@@ -123,11 +123,7 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {
-            "type": [
-              "null"
-            ]
-          }
+          "unit_amount_decimal": {}
         }
       }
     },
@@ -149,16 +145,8 @@
         "string"
       ]
     },
-    "item": {
-      "type": [
-        "null"
-      ]
-    },
-    "external_sku": {
-      "type": [
-        "null"
-      ]
-    },
+    "item": {},
+    "external_sku": {},
     "created_at": {
       "type": [
         "null",
@@ -171,10 +159,6 @@
         "string"
       ]
     },
-    "deleted_at": {
-      "type": [
-        "null"
-      ]
-    }
+    "deleted_at": {}
   }
 }

--- a/tap_recurly/schemas/plans_add_ons.json
+++ b/tap_recurly/schemas/plans_add_ons.json
@@ -123,7 +123,12 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {}
+          "unit_amount_decimal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
         }
       }
     },
@@ -145,8 +150,56 @@
         "string"
       ]
     },
-    "item": {},
-    "external_sku": {},
+    "item": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "external_sku": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "created_at": {
       "type": [
         "null",
@@ -159,6 +212,12 @@
         "string"
       ]
     },
-    "deleted_at": {}
+    "deleted_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    }
   }
 }

--- a/tap_recurly/schemas/subscriptions.json
+++ b/tap_recurly/schemas/subscriptions.json
@@ -70,17 +70,32 @@
             "string"
           ]
         },
-        "parent_account_id": {},
+        "parent_account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {}
+        "dunning_campaign_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
-    "billing_info_id": {},
+    "billing_info_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "active_invoice_id": {
       "type": [
         "null",
@@ -137,8 +152,156 @@
             "string"
           ]
         },
-        "address": {},
-        "method": {},
+        "address": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "object": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "account_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "nickname": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "first_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "company": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "email": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "vat_number": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "phone": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "street1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "street2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "city": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "region": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "postal_code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "method": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "object": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
         "amount": {
           "type": [
             "null",
@@ -322,7 +485,33 @@
             "null",
             "array"
           ],
-          "items": {}
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "starting_billing_cycle": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "remaining_billing_cycles": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "number"
+                ],
+                "format": "float"
+              }
+            }
+          }
         },
         "unit_amount": {
           "type": [
@@ -336,7 +525,32 @@
             "string"
           ]
         },
-        "custom_fields": {},
+        "custom_fields": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        },
         "quantity": {
           "type": [
             "null",
@@ -355,8 +569,156 @@
                 "string"
               ]
             },
-            "address": {},
-            "method": {},
+            "address": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "object": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "account_id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "nickname": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "first_name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "company": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "vat_number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "phone": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "street1": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "street2": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "city": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "region": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "postal_code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "country": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "created_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                }
+              }
+            },
+            "method": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "object": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "amount": {
               "type": [
                 "null",
@@ -389,7 +751,4878 @@
                 "string"
               ]
             },
-            "charge_invoice": {}
+            "charge_invoice": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "uuid": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "object": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "origin": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "state": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "account": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "object": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "email": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "format": "email"
+                    },
+                    "first_name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "last_name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "company": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "parent_account_id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "bill_to": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "dunning_campaign_id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                },
+                "billing_info_id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "subscription_ids": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "previous_invoice_id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "collection_method": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "po_number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "net_terms": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "address": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "phone": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "street1": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "street2": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "city": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "region": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "postal_code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "country": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                },
+                "shipping_address": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "object": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "account_id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "nickname": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "first_name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "last_name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "company": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "email": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "vat_number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "phone": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "street1": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "street2": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "city": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "region": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "postal_code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "country": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "created_at": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "currency": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "discount": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "subtotal": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "tax": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "total": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "refundable_amount": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "paid": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "balance": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "tax_info": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "region": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "rate": {
+                      "type": [
+                        "null",
+                        "number"
+                      ],
+                      "format": "float"
+                    },
+                    "tax_details": {
+                      "type": [
+                        "null",
+                        "array"
+                      ],
+                      "items": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "region": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "rate": {
+                            "type": [
+                              "null",
+                              "number"
+                            ],
+                            "format": "float"
+                          },
+                          "tax": {
+                            "type": [
+                              "null",
+                              "number"
+                            ],
+                            "format": "float"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "vat_number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "vat_reverse_charge_notes": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "terms_and_conditions": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "customer_notes": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "line_items": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "object": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "uuid": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "item_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "item_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "external_sku": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "revenue_schedule_type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "state": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "legacy_category": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "account": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "email"
+                          },
+                          "first_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "company": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "parent_account_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "bill_to": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "dunning_campaign_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "bill_for_account_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "subscription_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "plan_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "plan_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "add_on_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "add_on_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "invoice_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "invoice_number": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "previous_line_item_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "original_line_item_invoice_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "origin": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "accounting_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "product_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "credit_reason_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "currency": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "amount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "description": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "quantity": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "quantity_decimal": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "unit_amount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "unit_amount_decimal": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "tax_inclusive": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "subtotal": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "discount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "tax": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "taxable": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "tax_exempt": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "avalara_transaction_type": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "avalara_service_type": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "tax_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "tax_info": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "region": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "rate": {
+                            "type": [
+                              "null",
+                              "number"
+                            ],
+                            "format": "float"
+                          },
+                          "tax_details": {
+                            "type": [
+                              "null",
+                              "array"
+                            ],
+                            "items": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "region": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "rate": {
+                                  "type": [
+                                    "null",
+                                    "number"
+                                  ],
+                                  "format": "float"
+                                },
+                                "tax": {
+                                  "type": [
+                                    "null",
+                                    "number"
+                                  ],
+                                  "format": "float"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "proration_rate": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "refund": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "refunded_quantity": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "refunded_quantity_decimal": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "credit_applied": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "shipping_address": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "account_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "nickname": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "first_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "company": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "vat_number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "phone": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "street1": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "street2": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "city": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "region": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "postal_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "country": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      },
+                      "start_date": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "end_date": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "custom_fields": {
+                        "type": [
+                          "null",
+                          "array"
+                        ],
+                        "items": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "value": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "created_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                },
+                "has_more_line_items": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                },
+                "transactions": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "object": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "uuid": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "original_transaction_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "account": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "email"
+                          },
+                          "first_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "company": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "parent_account_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "bill_to": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "dunning_campaign_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "invoice": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "state": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "voided_by_invoice": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "state": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "subscription_ids": {
+                        "type": [
+                          "null",
+                          "array"
+                        ],
+                        "items": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        }
+                      },
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "origin": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "currency": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "amount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "status": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "success": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "backup_payment_method_used": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "refunded": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      },
+                      "billing_address": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "phone": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "street1": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "street2": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "city": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "region": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "postal_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "country": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "collection_method": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "payment_method": {
+                        "properties": {
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "card_type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "first_six": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_four": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_two": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "exp_month": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "exp_year": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "gateway_token": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "cc_bin_country": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "gateway_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "billing_agreement_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "name_on_account": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "account_type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "routing_number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "routing_number_bank": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "username": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "ip_address_v4": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "ip_address_country": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "status_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "status_message": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "customer_message": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "customer_message_locale": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "payment_gateway": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "gateway_message": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "gateway_reference": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "gateway_approval_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "gateway_response_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "gateway_response_time": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "gateway_response_values": {
+                        "type": [
+                          "null",
+                          "object"
+                        ]
+                      },
+                      "cvv_check": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "avs_check": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "created_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "voided_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "collected_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                },
+                "credit_payments": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "object": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "uuid": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "action": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "account": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "email"
+                          },
+                          "first_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "last_name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "company": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "parent_account_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "bill_to": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "dunning_campaign_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "applied_to_invoice": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "state": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "original_invoice": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "state": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        }
+                      },
+                      "currency": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "amount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "original_credit_payment_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "refund_transaction": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "object": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "uuid": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "original_transaction_id": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "account": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "object": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "code": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "email": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ],
+                                "format": "email"
+                              },
+                              "first_name": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "last_name": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "company": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "parent_account_id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "bill_to": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "dunning_campaign_id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "invoice": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "object": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "number": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "state": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "voided_by_invoice": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "object": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "number": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "state": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "subscription_ids": {
+                            "type": [
+                              "null",
+                              "array"
+                            ],
+                            "items": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          },
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "origin": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "currency": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "amount": {
+                            "type": [
+                              "null",
+                              "number"
+                            ],
+                            "format": "float"
+                          },
+                          "status": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "success": {
+                            "type": [
+                              "null",
+                              "boolean"
+                            ]
+                          },
+                          "backup_payment_method_used": {
+                            "type": [
+                              "null",
+                              "boolean"
+                            ]
+                          },
+                          "refunded": {
+                            "type": [
+                              "null",
+                              "boolean"
+                            ]
+                          },
+                          "billing_address": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "phone": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "street1": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "street2": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "city": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "region": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "postal_code": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "country": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "collection_method": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "payment_method": {
+                            "properties": {
+                              "object": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "card_type": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "first_six": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "last_four": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "last_two": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "exp_month": {
+                                "type": [
+                                  "null",
+                                  "integer"
+                                ]
+                              },
+                              "exp_year": {
+                                "type": [
+                                  "null",
+                                  "integer"
+                                ]
+                              },
+                              "gateway_token": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "cc_bin_country": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "gateway_code": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "billing_agreement_id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "name_on_account": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "account_type": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "routing_number": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "routing_number_bank": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "username": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "ip_address_v4": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ip_address_country": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "status_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "status_message": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "customer_message": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "customer_message_locale": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "payment_gateway": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "object": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "name": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          },
+                          "gateway_message": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "gateway_reference": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "gateway_approval_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "gateway_response_code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "gateway_response_time": {
+                            "type": [
+                              "null",
+                              "number"
+                            ],
+                            "format": "float"
+                          },
+                          "gateway_response_values": {
+                            "type": [
+                              "null",
+                              "object"
+                            ]
+                          },
+                          "cvv_check": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "avs_check": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          },
+                          "voided_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          },
+                          "collected_at": {
+                            "type": [
+                              "null",
+                              "string"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      },
+                      "created_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "voided_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                },
+                "created_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                },
+                "due_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                },
+                "closed_at": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "format": "date-time"
+                },
+                "dunning_campaign_id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "dunning_events_sent": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "final_dunning_event": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                }
+              }
+            },
+            "credit_invoices": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "items": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "uuid": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "origin": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "state": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "account": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "object": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "email"
+                      },
+                      "first_name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "last_name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "company": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "parent_account_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "bill_to": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "dunning_campaign_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "billing_info_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "subscription_ids": {
+                    "type": [
+                      "null",
+                      "array"
+                    ],
+                    "items": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "previous_invoice_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "collection_method": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "po_number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "net_terms": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "address": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "phone": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "street1": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "street2": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "city": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "region": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "postal_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "country": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "shipping_address": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "object": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "account_id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "nickname": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "first_name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "last_name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "company": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "vat_number": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "phone": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "street1": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "street2": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "city": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "region": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "postal_code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "country": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "created_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "format": "date-time"
+                      }
+                    }
+                  },
+                  "currency": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "discount": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "subtotal": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "tax": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "total": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "refundable_amount": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "paid": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "balance": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "tax_info": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "region": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "rate": {
+                        "type": [
+                          "null",
+                          "number"
+                        ],
+                        "format": "float"
+                      },
+                      "tax_details": {
+                        "type": [
+                          "null",
+                          "array"
+                        ],
+                        "items": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "region": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "rate": {
+                              "type": [
+                                "null",
+                                "number"
+                              ],
+                              "format": "float"
+                            },
+                            "tax": {
+                              "type": [
+                                "null",
+                                "number"
+                              ],
+                              "format": "float"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "vat_number": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "vat_reverse_charge_notes": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "terms_and_conditions": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "customer_notes": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "line_items": {
+                    "type": [
+                      "null",
+                      "array"
+                    ],
+                    "items": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "object": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "uuid": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "item_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "item_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "external_sku": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "revenue_schedule_type": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "state": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "legacy_category": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "account": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "email": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "email"
+                            },
+                            "first_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "company": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "parent_account_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "bill_to": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "dunning_campaign_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "bill_for_account_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "subscription_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "plan_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "plan_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "add_on_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "add_on_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "invoice_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "invoice_number": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "previous_line_item_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "original_line_item_invoice_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "origin": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "accounting_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "product_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "credit_reason_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "currency": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "amount": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "description": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "quantity": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "quantity_decimal": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "unit_amount": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "unit_amount_decimal": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "tax_inclusive": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "subtotal": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "discount": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "tax": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "taxable": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "tax_exempt": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "avalara_transaction_type": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "avalara_service_type": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "tax_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "tax_info": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "region": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "rate": {
+                              "type": [
+                                "null",
+                                "number"
+                              ],
+                              "format": "float"
+                            },
+                            "tax_details": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "object"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": [
+                                      "null",
+                                      "string"
+                                    ]
+                                  },
+                                  "region": {
+                                    "type": [
+                                      "null",
+                                      "string"
+                                    ]
+                                  },
+                                  "rate": {
+                                    "type": [
+                                      "null",
+                                      "number"
+                                    ],
+                                    "format": "float"
+                                  },
+                                  "tax": {
+                                    "type": [
+                                      "null",
+                                      "number"
+                                    ],
+                                    "format": "float"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "proration_rate": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "refund": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "refunded_quantity": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "refunded_quantity_decimal": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "credit_applied": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "shipping_address": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "account_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "nickname": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "first_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "company": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "email": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "vat_number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "phone": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "street1": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "street2": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "city": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "region": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "postal_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "country": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "created_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            }
+                          }
+                        },
+                        "start_date": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "end_date": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "custom_fields": {
+                          "type": [
+                            "null",
+                            "array"
+                          ],
+                          "items": {
+                            "type": [
+                              "null",
+                              "object"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              },
+                              "value": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "created_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  },
+                  "has_more_line_items": {
+                    "type": [
+                      "null",
+                      "boolean"
+                    ]
+                  },
+                  "transactions": {
+                    "type": [
+                      "null",
+                      "array"
+                    ],
+                    "items": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "object": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "uuid": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "original_transaction_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "account": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "email": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "email"
+                            },
+                            "first_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "company": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "parent_account_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "bill_to": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "dunning_campaign_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "invoice": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "state": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "voided_by_invoice": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "state": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "subscription_ids": {
+                          "type": [
+                            "null",
+                            "array"
+                          ],
+                          "items": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "origin": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "currency": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "amount": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "status": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "success": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "backup_payment_method_used": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "refunded": {
+                          "type": [
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "billing_address": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "phone": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "street1": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "street2": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "city": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "region": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "postal_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "country": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "collection_method": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "payment_method": {
+                          "properties": {
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "card_type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "first_six": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_four": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_two": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "exp_month": {
+                              "type": [
+                                "null",
+                                "integer"
+                              ]
+                            },
+                            "exp_year": {
+                              "type": [
+                                "null",
+                                "integer"
+                              ]
+                            },
+                            "gateway_token": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "cc_bin_country": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "gateway_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "billing_agreement_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "name_on_account": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "account_type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "routing_number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "routing_number_bank": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "username": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "ip_address_v4": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "ip_address_country": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "status_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "status_message": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "customer_message": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "customer_message_locale": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "payment_gateway": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "gateway_message": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "gateway_reference": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "gateway_approval_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "gateway_response_code": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "gateway_response_time": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "gateway_response_values": {
+                          "type": [
+                            "null",
+                            "object"
+                          ]
+                        },
+                        "cvv_check": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "avs_check": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "created_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "voided_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "collected_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  },
+                  "credit_payments": {
+                    "type": [
+                      "null",
+                      "array"
+                    ],
+                    "items": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "object": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "uuid": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "action": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "account": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "email": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "email"
+                            },
+                            "first_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "last_name": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "company": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "parent_account_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "bill_to": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "dunning_campaign_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "applied_to_invoice": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "state": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "original_invoice": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "number": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "state": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            }
+                          }
+                        },
+                        "currency": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "amount": {
+                          "type": [
+                            "null",
+                            "number"
+                          ],
+                          "format": "float"
+                        },
+                        "original_credit_payment_id": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "refund_transaction": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "object": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "uuid": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "original_transaction_id": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "account": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "object": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "code": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "email": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ],
+                                  "format": "email"
+                                },
+                                "first_name": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "last_name": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "company": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "parent_account_id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "bill_to": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "dunning_campaign_id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "invoice": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "object": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "number": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "state": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "voided_by_invoice": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "object": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "number": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "state": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "subscription_ids": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "origin": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "currency": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "amount": {
+                              "type": [
+                                "null",
+                                "number"
+                              ],
+                              "format": "float"
+                            },
+                            "status": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "success": {
+                              "type": [
+                                "null",
+                                "boolean"
+                              ]
+                            },
+                            "backup_payment_method_used": {
+                              "type": [
+                                "null",
+                                "boolean"
+                              ]
+                            },
+                            "refunded": {
+                              "type": [
+                                "null",
+                                "boolean"
+                              ]
+                            },
+                            "billing_address": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "phone": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "street1": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "street2": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "city": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "region": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "postal_code": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "country": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "collection_method": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "payment_method": {
+                              "properties": {
+                                "object": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "card_type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "first_six": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "last_four": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "last_two": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "exp_month": {
+                                  "type": [
+                                    "null",
+                                    "integer"
+                                  ]
+                                },
+                                "exp_year": {
+                                  "type": [
+                                    "null",
+                                    "integer"
+                                  ]
+                                },
+                                "gateway_token": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "cc_bin_country": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "gateway_code": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "billing_agreement_id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "name_on_account": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "account_type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "routing_number": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "routing_number_bank": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "username": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "ip_address_v4": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "ip_address_country": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "status_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "status_message": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "customer_message": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "customer_message_locale": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "payment_gateway": {
+                              "type": [
+                                "null",
+                                "object"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "object": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              }
+                            },
+                            "gateway_message": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "gateway_reference": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "gateway_approval_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "gateway_response_code": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "gateway_response_time": {
+                              "type": [
+                                "null",
+                                "number"
+                              ],
+                              "format": "float"
+                            },
+                            "gateway_response_values": {
+                              "type": [
+                                "null",
+                                "object"
+                              ]
+                            },
+                            "cvv_check": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "avs_check": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "created_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "voided_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            },
+                            "collected_at": {
+                              "type": [
+                                "null",
+                                "string"
+                              ],
+                              "format": "date-time"
+                            }
+                          }
+                        },
+                        "created_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        },
+                        "voided_at": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  },
+                  "created_at": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "date-time"
+                  },
+                  "due_at": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "date-time"
+                  },
+                  "closed_at": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "date-time"
+                  },
+                  "dunning_campaign_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "dunning_events_sent": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "final_dunning_event": {
+                    "type": [
+                      "null",
+                      "boolean"
+                    ]
+                  }
+                }
+              }
+            }
           }
         },
         "created_at": {
@@ -404,9 +5637,264 @@
             "string"
           ]
         },
-        "deleted_at": {},
-        "add_ons": {},
-        "invoice_collection": {}
+        "deleted_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "add_ons": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "object": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "subscription_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "add_on": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "code": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "add_on_type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "usage_type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "usage_percentage": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "float"
+                  },
+                  "measured_unit_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "item_id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "external_sku": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "accounting_code": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "add_on_source": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "quantity": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "number"
+                ],
+                "format": "float"
+              },
+              "unit_amount_decimal": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "decimal"
+              },
+              "revenue_schedule_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "tier_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "usage_calculation_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "usage_timeframe": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "tiers": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "ending_quantity": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "unit_amount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ],
+                      "format": "float"
+                    },
+                    "unit_amount_decimal": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "usage_percentage": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              },
+              "percentage_tiers": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "ending_amount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ],
+                      "format": "float"
+                    },
+                    "usage_percentage": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              },
+              "usage_percentage": {
+                "type": [
+                  "null",
+                  "number"
+                ],
+                "format": "float"
+              },
+              "created_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              },
+              "expired_at": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "date-time"
+              }
+            }
+          }
+        }
       }
     },
     "ramp_intervals": {
@@ -414,7 +5902,33 @@
         "null",
         "array"
       ],
-      "items": {}
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "starting_billing_cycle": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "remaining_billing_cycles": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_amount": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "float"
+          }
+        }
+      }
     },
     "current_period_started_at": {
       "type": [
@@ -440,8 +5954,20 @@
         "string"
       ]
     },
-    "trial_started_at": {},
-    "trial_ends_at": {},
+    "trial_started_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "trial_ends_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
     "remaining_billing_cycles": {
       "type": [
         "null",
@@ -472,15 +5998,31 @@
         "boolean"
       ]
     },
-    "paused_at": {},
-    "remaining_pause_cycles": {},
+    "paused_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "remaining_pause_cycles": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "currency": {
       "type": [
         "null",
         "string"
       ]
     },
-    "tax_inclusive": {},
+    "tax_inclusive": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "unit_amount": {
       "type": [
         "null",
@@ -541,8 +6083,19 @@
         "string"
       ]
     },
-    "bank_account_authorized_at": {},
-    "gateway_code": {},
+    "bank_account_authorized_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "gateway_code": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "started_with_gift": {
       "type": [
         "null",
@@ -585,7 +6138,26 @@
         "null",
         "array"
       ],
-      "items": {}
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
     },
     "tax": {
       "type": [
@@ -702,8 +6274,18 @@
                   "string"
                 ]
               },
-              "item_id": {},
-              "external_sku": {},
+              "item_id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "external_sku": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
               "accounting_code": {
                 "type": [
                   "null",
@@ -730,7 +6312,13 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {},
+          "unit_amount_decimal": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "decimal"
+          },
           "usage_percentage": {
             "type": [
               "null",
@@ -779,8 +6367,72 @@
               "string"
             ]
           },
-          "percentage_tiers": {},
-          "tiers": {}
+          "percentage_tiers": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "ending_amount": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "usage_percentage": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
+          "tiers": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "ending_quantity": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "unit_amount": {
+                  "type": [
+                    "null",
+                    "number"
+                  ],
+                  "format": "float"
+                },
+                "unit_amount_decimal": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "usage_percentage": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/tap_recurly/schemas/subscriptions.json
+++ b/tap_recurly/schemas/subscriptions.json
@@ -70,29 +70,17 @@
             "string"
           ]
         },
-        "parent_account_id": {
-          "type": [
-            "null"
-          ]
-        },
+        "parent_account_id": {},
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {
-          "type": [
-            "null"
-          ]
-        }
+        "dunning_campaign_id": {}
       }
     },
-    "billing_info_id": {
-      "type": [
-        "null"
-      ]
-    },
+    "billing_info_id": {},
     "active_invoice_id": {
       "type": [
         "null",
@@ -149,16 +137,8 @@
             "string"
           ]
         },
-        "address": {
-          "type": [
-            "null"
-          ]
-        },
-        "method": {
-          "type": [
-            "null"
-          ]
-        },
+        "address": {},
+        "method": {},
         "amount": {
           "type": [
             "null",
@@ -339,8 +319,10 @@
         },
         "ramp_intervals": {
           "type": [
-            "null"
-          ]
+            "null",
+            "array"
+          ],
+          "items": {}
         },
         "unit_amount": {
           "type": [
@@ -354,11 +336,7 @@
             "string"
           ]
         },
-        "custom_fields": {
-          "type": [
-            "null"
-          ]
-        },
+        "custom_fields": {},
         "quantity": {
           "type": [
             "null",
@@ -377,16 +355,8 @@
                 "string"
               ]
             },
-            "address": {
-              "type": [
-                "null"
-              ]
-            },
-            "method": {
-              "type": [
-                "null"
-              ]
-            },
+            "address": {},
+            "method": {},
             "amount": {
               "type": [
                 "null",
@@ -419,11 +389,7 @@
                 "string"
               ]
             },
-            "charge_invoice": {
-              "type": [
-                "null"
-              ]
-            }
+            "charge_invoice": {}
           }
         },
         "created_at": {
@@ -438,12 +404,17 @@
             "string"
           ]
         },
-        "deleted_at": {
-          "type": [
-            "null"
-          ]
-        }
+        "deleted_at": {},
+        "add_ons": {},
+        "invoice_collection": {}
       }
+    },
+    "ramp_intervals": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
     },
     "current_period_started_at": {
       "type": [
@@ -469,16 +440,8 @@
         "string"
       ]
     },
-    "trial_started_at": {
-      "type": [
-        "null"
-      ]
-    },
-    "trial_ends_at": {
-      "type": [
-        "null"
-      ]
-    },
+    "trial_started_at": {},
+    "trial_ends_at": {},
     "remaining_billing_cycles": {
       "type": [
         "null",
@@ -509,27 +472,15 @@
         "boolean"
       ]
     },
-    "paused_at": {
-      "type": [
-        "null"
-      ]
-    },
-    "remaining_pause_cycles": {
-      "type": [
-        "null"
-      ]
-    },
+    "paused_at": {},
+    "remaining_pause_cycles": {},
     "currency": {
       "type": [
         "null",
         "string"
       ]
     },
-    "tax_inclusive": {
-      "type": [
-        "null"
-      ]
-    },
+    "tax_inclusive": {},
     "unit_amount": {
       "type": [
         "null",
@@ -590,27 +541,15 @@
         "string"
       ]
     },
-    "bank_account_authorized_at": {
-      "type": [
-        "null"
-      ]
-    },
-    "gateway_code": {
-      "type": [
-        "null"
-      ]
-    },
+    "bank_account_authorized_at": {},
+    "gateway_code": {},
     "started_with_gift": {
       "type": [
         "null",
         "boolean"
       ]
     },
-    "converted_at": {
-      "type": [
-        "null"
-      ]
-    },
+    "converted_at": {},
     "created_at": {
       "type": [
         "null",
@@ -640,6 +579,13 @@
         "null",
         "string"
       ]
+    },
+    "custom_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
     },
     "tax": {
       "type": [
@@ -756,16 +702,8 @@
                   "string"
                 ]
               },
-              "item_id": {
-                "type": [
-                  "null"
-                ]
-              },
-              "external_sku": {
-                "type": [
-                  "null"
-                ]
-              },
+              "item_id": {},
+              "external_sku": {},
               "accounting_code": {
                 "type": [
                   "null",
@@ -792,11 +730,7 @@
               "number"
             ]
           },
-          "unit_amount_decimal": {
-            "type": [
-              "null"
-            ]
-          },
+          "unit_amount_decimal": {},
           "usage_percentage": {
             "type": [
               "null",
@@ -841,9 +775,12 @@
           },
           "expired_at": {
             "type": [
-              "null"
+              "null",
+              "string"
             ]
-          }
+          },
+          "percentage_tiers": {},
+          "tiers": {}
         }
       }
     }

--- a/tap_recurly/schemas/transactions.json
+++ b/tap_recurly/schemas/transactions.json
@@ -64,27 +64,15 @@
             "string"
           ]
         },
-        "company": {
-          "type": [
-            "null"
-          ]
-        },
-        "parent_account_id": {
-          "type": [
-            "null"
-          ]
-        },
+        "company": {},
+        "parent_account_id": {},
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {
-          "type": [
-            "null"
-          ]
-        }
+        "dunning_campaign_id": {}
       }
     },
     "invoice": {
@@ -125,11 +113,7 @@
         }
       }
     },
-    "voided_by_invoice": {
-      "type": [
-        "null"
-      ]
-    },
+    "voided_by_invoice": {},
     "subscription_ids": {
       "type": [
         "null",
@@ -250,11 +234,7 @@
             "string"
           ]
         },
-        "phone": {
-          "type": [
-            "null"
-          ]
-        }
+        "phone": {}
       }
     },
     "collection_method": {
@@ -293,11 +273,7 @@
             "string"
           ]
         },
-        "cc_bin_country": {
-          "type": [
-            "null"
-          ]
-        },
+        "cc_bin_country": {},
         "exp_month": {
           "type": [
             "null",
@@ -392,11 +368,7 @@
         "string"
       ]
     },
-    "gateway_approval_code": {
-      "type": [
-        "null"
-      ]
-    },
+    "gateway_approval_code": {},
     "gateway_response_code": {
       "type": [
         "null",
@@ -421,11 +393,7 @@
             "string"
           ]
         },
-        "transaction_type": {
-          "type": [
-            "null"
-          ]
-        }
+        "transaction_type": {}
       }
     },
     "cvv_check": {

--- a/tap_recurly/schemas/transactions.json
+++ b/tap_recurly/schemas/transactions.json
@@ -64,15 +64,30 @@
             "string"
           ]
         },
-        "company": {},
-        "parent_account_id": {},
+        "company": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "parent_account_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "bill_to": {
           "type": [
             "null",
             "string"
           ]
         },
-        "dunning_campaign_id": {}
+        "dunning_campaign_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
     "invoice": {
@@ -113,7 +128,44 @@
         }
       }
     },
-    "voided_by_invoice": {},
+    "voided_by_invoice": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "number": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "subscription_ids": {
       "type": [
         "null",
@@ -234,7 +286,12 @@
             "string"
           ]
         },
-        "phone": {}
+        "phone": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
       }
     },
     "collection_method": {
@@ -273,7 +330,12 @@
             "string"
           ]
         },
-        "cc_bin_country": {},
+        "cc_bin_country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "exp_month": {
           "type": [
             "null",
@@ -368,7 +430,12 @@
         "string"
       ]
     },
-    "gateway_approval_code": {},
+    "gateway_approval_code": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "gateway_response_code": {
       "type": [
         "null",


### PR DESCRIPTION
Extending and adding to schemas.
Schemas were previously made by infering from tap output. This meant that unusual fields were listed as "null" type. Missing schema entries were inserted from the openAPI doc.